### PR TITLE
Email password sad paths

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,10 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = User.create(user_params)
+    new_user_params = user_params
+    new_user_params[:email] = new_user_params[:email].downcase
+
+    user = User.create(new_user_params)
     if user.save
       redirect_to dashboard_path
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,8 +4,13 @@ class UsersController < ApplicationController
   end
 
   def create
-    user = User.create!(user_params)
-    redirect_to dashboard_path
+    user = User.create(user_params)
+    if user.save
+      redirect_to dashboard_path
+    else
+      flash[:error] = user.errors.full_messages.to_sentence
+      render :new
+    end
   end
 
   def show

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -20,6 +20,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :password)
+    params.require(:user).permit(:email, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  validates :email, uniqueness: true, presence: true
+  validates :email, uniqueness: true, presence: true, format: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
   validates :password, presence: true, confirmation: true
   has_secure_password
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   validates :email, uniqueness: true, presence: true, format: /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/
-  validates :password, presence: true, confirmation: true
+  validates :password, presence: true
+  validates :password, confirmation: true
   has_secure_password
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
 
   <body>
     <main>
+      <% flash.each do |name, msg| %>
+        <%= content_tag :div, msg, class: name %>
+      <% end %>
       <%= yield %>
     </main>
     <footer>

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe 'Registration Page' do
 
       expect(current_path).to eq('/dashboard')
     end
+
+     it 'saves user email downcased' do
+       email = "ExamplE@example.com"
+       password = "test"
+       fill_in "user[email]", with: email
+       fill_in "user[password]", with: password
+       fill_in "user[password_confirmation]", with: password
+       click_button "Register"
+
+       user = User.last
+       downcase_email = email.downcase
+binding.pry
+       expect(user.email).to eq(downcase_email)
+     end
   end
 
   describe 'sad path and edge case' do
@@ -86,7 +100,7 @@ RSpec.describe 'Registration Page' do
       fill_in "user[password]", with: password
       fill_in "user[password_confirmation]", with: "wrong0password"
       click_button "Register"
-      
+
       confirmation_error = "Password confirmation doesn't match Password"
 
       expect(page).to have_content(confirmation_error)

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -20,4 +20,19 @@ RSpec.describe 'Registration Page' do
       expect(current_path).to eq('/dashboard')
     end
   end
+
+  describe 'sad path' do
+    it 'email field cannot be blank' do
+
+      password = "test"
+      
+      fill_in "user[password]", with: password
+      fill_in "user[password_confirmation]", with: password
+      click_button "Register"
+
+      blank_email_notice = "An email is required to create your account"
+
+      expect(page).to have_content(blank_email_notice)
+    end
+  end
 end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -46,5 +46,18 @@ RSpec.describe 'Registration Page' do
 
       expect(page).to have_content(blank_password_notice)
     end
+
+    it 'must be a valid email format' do
+
+      fill_in "user[email]", with: "iloveMovies.com"
+      fill_in "user[password]", with: "password"
+      fill_in "user[password_confirmation]", with: "password"
+
+      click_on "Register"
+
+      invalid_email = "Email is invalid"
+
+      expect(page).to have_content(invalid_email)
+    end
   end
 end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -21,11 +21,10 @@ RSpec.describe 'Registration Page' do
     end
   end
 
-  describe 'sad path' do
+  describe 'sad path and edge case' do
     it 'email field cannot be blank' do
 
       password = "test"
-
       fill_in "user[password]", with: password
       fill_in "user[password_confirmation]", with: password
       click_button "Register"
@@ -38,7 +37,6 @@ RSpec.describe 'Registration Page' do
     it 'password field cannot be blank' do
 
       email = "example@example.com"
-
       fill_in "user[email]", with: email
       click_button "Register"
 
@@ -52,12 +50,46 @@ RSpec.describe 'Registration Page' do
       fill_in "user[email]", with: "iloveMovies.com"
       fill_in "user[password]", with: "password"
       fill_in "user[password_confirmation]", with: "password"
-
       click_on "Register"
 
       invalid_email = "Email is invalid"
 
       expect(page).to have_content(invalid_email)
+    end
+
+    it 'cannot register with existing account email' do
+      email = "example@example.com"
+      password = "test"
+      fill_in "user[email]", with: email
+      fill_in "user[password]", with: password
+      fill_in "user[password_confirmation]", with: password
+      click_button "Register"
+
+      expect(current_path).to eq('/dashboard')
+
+      visit "/registration"
+
+      fill_in "user[email]", with: email
+      fill_in "user[password]", with: password
+      fill_in "user[password_confirmation]", with: password
+      click_button "Register"
+
+      account_exists = "Email has already been taken"
+
+      expect(page).to have_content(account_exists)
+    end
+
+    it 'password and password confirmation must match' do
+      email = "example@example.com"
+      password = "test"
+      fill_in "user[email]", with: email
+      fill_in "user[password]", with: password
+      fill_in "user[password_confirmation]", with: "wrong0password"
+      click_button "Register"
+      
+      confirmation_error = "Password confirmation doesn't match Password"
+
+      expect(page).to have_content(confirmation_error)
     end
   end
 end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Registration Page' do
 
        user = User.last
        downcase_email = email.downcase
-binding.pry
+       
        expect(user.email).to eq(downcase_email)
      end
   end

--- a/spec/features/users/registration_spec.rb
+++ b/spec/features/users/registration_spec.rb
@@ -25,14 +25,26 @@ RSpec.describe 'Registration Page' do
     it 'email field cannot be blank' do
 
       password = "test"
-      
+
       fill_in "user[password]", with: password
       fill_in "user[password_confirmation]", with: password
       click_button "Register"
 
-      blank_email_notice = "An email is required to create your account"
+      blank_email_notice = "Email can't be blank"
 
       expect(page).to have_content(blank_email_notice)
+    end
+
+    it 'password field cannot be blank' do
+
+      email = "example@example.com"
+
+      fill_in "user[email]", with: email
+      click_button "Register"
+
+      blank_password_notice = "Password can't be blank"
+
+      expect(page).to have_content(blank_password_notice)
     end
   end
 end


### PR DESCRIPTION
## Modifies
- `app/controllers/users_controller.rb`: downcase the user email from registration form, add flash notice for error messages, pass `:password_confirmation` in strong params
- `spec/features/users/registration_spec.rb`: add sad paths tests for email format, password confirmation, and blank fields.
- `app/views/layouts/application.html.erb`: add flash messages block
<details>
<summary>Issues</summary>
  closes #21 
<br>
</details>
