### PR TITLE
Add filter to simplecov coverage

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 SimpleCov.start
+SimpleCov.add_filter ['spec', 'config', 'app/channels', 'app/jobs', 'app/mailers']
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
## Modifies
- `spec/rails_helper.rb`: Add folders for simplecov to filter so that coverage reflect code written by us only 

closes #37 