### PR TITLE
Make sad path for blank search field on discover page

### DIFF
--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,11 +1,14 @@
 class MoviesController < ApplicationController
   def index
-    if params["movie_title"]
+    if params["movie_title"] == ""
+      flash[:error] = "Search field cannot be blank."
+      redirect_to discover_path
+    elsif params["movie_title"]
       movie_keyword = params["movie_title"]
       response = Faraday.get("https://api.themoviedb.org/3/search/movie?api_key=#{ENV['MOVIE_KEY']}&language=en-US&page=1&include_adult=false") do |req|
         req.params['query'] = movie_keyword
       end
-      parsed = JSON.parse(response.body, symbolize_names: true)  
+      parsed = JSON.parse(response.body, symbolize_names: true)
       @search_results = parsed[:results].map do |result|
         Film.new(result)
       end.first(40)

--- a/app/views/discover/index.html.erb
+++ b/app/views/discover/index.html.erb
@@ -1,6 +1,6 @@
 <%= button_to "Top 40 Movies", movies_path, method: :get %>
 <%= form_with url: movies_path, method: :get, local: true do |f| %>
   <%= f.label :movie_title, "Search for Movie by Title: " %>
-  <%= f.text_field :movie_title %>
+  <%= f.text_field :movie_title, required: true %>
   <%= f.submit "Search" %>
 <% end %>

--- a/spec/features/discover/index_spec.rb
+++ b/spec/features/discover/index_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe 'Discover Page' do
       expect(current_path).to eq('/movies')
     end
   end
+
+  describe 'sad paths and edge cases' do
+    it 'shows message if search field is blank' do
+      fill_in :movie_title, with: ""
+      click_button "Search"
+      expect(page).to have_content("Search field cannot be blank.")
+    end
+  end
 end


### PR DESCRIPTION
Co-authored-by: Diana Buffone <71909590+Diana20920@users.noreply.github.com>

## Modifies
- `app/controllers/movies_controller.rb`:  Added flash message if search field is blank
- `app/views/discover/index.html.erb`: Made search field required
<details>
<summary>Issues</summary>
  closes #38 
<br>
</details>
