### PR TITLE
Display message in new party form if no friends

### DIFF
--- a/app/views/parties/new.html.erb
+++ b/app/views/parties/new.html.erb
@@ -12,13 +12,18 @@
   <%= f.label :start_time, 'Start Time: ' %>
   <%= f.time_field :start_time %>
 
-  <p>Include Some Friends:</p>
-   <% current_user.friends.each do |friend| %>
-    <div id="friend-<%= friend.id %>">
-      <%= f.label friend.email %>
-      <%= f.check_box friend.email %><br><br>
-    </div>
-   <% end %>
+  <% if current_user.friends.empty? %>
+    <p>Seems like you have not added friends yet.<br>
+      Just a heads up that you will not be able to modify this event once it has been created.</p>
+  <% else %>
+    <p>Include Some Friends:</p>
+     <% current_user.friends.each do |friend| %>
+      <div id="friend-<%= friend.id %>">
+        <%= f.label friend.email %>
+        <%= f.check_box friend.email %><br><br>
+      </div>
+     <% end %>
+  <% end %>
 
    <%= f.submit 'Create Party' %>
 <% end %>

--- a/spec/features/parties/new_spec.rb
+++ b/spec/features/parties/new_spec.rb
@@ -40,4 +40,25 @@ RSpec.describe 'New Party Page' do
       expect(current_path).to eq('/dashboard')
     end
   end
+
+  describe 'sad paths and edge cases' do
+    it 'displays message when user has no friends' do
+      VCR.use_cassette('hamilton_details') do
+        Friendship.destroy_all
+
+        visit '/movies/556574'
+        click_button 'Create Viewing Party for Movie'
+
+        fill_in :date, with: '2021-05-16'
+        fill_in :start_time, with: '07:00 PM'
+
+        message = 'Seems like you have not added friends yet. Just a heads up that you will not be able to modify this event once it has been created.'
+        expect(page).to have_content(message)
+
+        click_button 'Create Party'
+
+        expect(current_path).to eq('/dashboard')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Modifies
- `app/views/parties/new.html.erb`: display message for user that event cannot be updated once it is created since user has no friends to add to party event.
- `spec/features/parties/new_spec.rb`: account for user having no friends when creating party since edit feature is not available.
<details>
<summary>Issues</summary>
  closes #57 
<br>
</details>
