### PR TITLE
Make fields required in new party view

### DIFF
--- a/app/views/parties/new.html.erb
+++ b/app/views/parties/new.html.erb
@@ -4,13 +4,13 @@
   <%= f.hidden_field :title, value: @movie_title %>
   <%= f.hidden_field :movie_id, value: @movie_id %>
   <%= f.label :duration, 'Duration of Party: ' %>
-  <%= f.number_field :duration, value: @movie_runtime, min: @movie_runtime %>
+  <%= f.number_field :duration, value: @movie_runtime, min: @movie_runtime, required: true %>
 
   <%= f.label :date, 'Date: ' %>
-  <%= f.date_field :date %>
+  <%= f.date_field :date, required: true %>
 
   <%= f.label :start_time, 'Start Time: ' %>
-  <%= f.time_field :start_time %>
+  <%= f.time_field :start_time, required: true %>
 
   <p>Include Some Friends:</p>
    <% current_user.friends.each do |friend| %>

--- a/spec/features/parties/new_spec.rb
+++ b/spec/features/parties/new_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'New Party Page' do
       expect(page).to have_field(:duration, with: "160")
       expect(page).to have_field(:date)
       expect(page).to have_field(:start_time)
-      expect(page).to have_field(:start_time)
       expect(page).to have_unchecked_field("#{@user.friends.first.email}")
 
       within("#friend-#{@friend.id}") do


### PR DESCRIPTION
Co-authored-by: Diana Buffone <71909590+Diana20920@users.noreply.github.com>

## Modifies
- `app/views/parties/new.html.erb`: require fields in new party form to be filled in. Tried to make this work in backend with a sad path but couldn't get it to `render :new` without also losing the movie title and movie_api_id. Tried using strong params too and that didn't work. I think it has to do with the form with model because the error I got said the path in the form wasn't recognized.
- `spec/features/parties/new_spec.rb`: removed duplicate line from test
